### PR TITLE
Create Wyre account with the unique key

### DIFF
--- a/src/containers/BuySellCrypto/BuyCrypto/BuyCrypto.js
+++ b/src/containers/BuySellCrypto/BuyCrypto/BuyCrypto.js
@@ -53,7 +53,7 @@ import {
   selectExchangeRatesIsFetching,
 } from '../../../selectors/paymentMethods';
 import { selectWyrePaymentMethod } from '../../../selectors/authentication';
-
+import hasPaymentMethod from '../../../utils/paymentMethod';
 class BuyCrypto extends Component {
   constructor(props) {
     super(props);
@@ -99,7 +99,7 @@ class BuyCrypto extends Component {
 
   _handleSubmit = () => {
     Keyboard.dismiss();
-    if (!this.props.paymentMethod){
+    if (!hasPaymentMethod(this.props.paymentMethod)){
       DelayedAlert('Please Manage Account first')
       this.props.navigation.navigate('SelectPaymentMethod', {
         onSelect: this.switchPaymentMethod,
@@ -323,7 +323,7 @@ class BuyCrypto extends Component {
         _errors = true
       }
 
-      if (!_errors && this.props.paymentMethod) {
+      if (!_errors && hasPaymentMethod(this.props.paymentMethod)) {
         switch (this.state.paymentMethod.id) {
           case 'US_BANK_ACCT':
               this.usBankAcctPayment(

--- a/src/services/wyreService.js
+++ b/src/services/wyreService.js
@@ -4,8 +4,6 @@ import RNFetchBlob from 'rn-fetch-blob';
 
 import { WYRE_URL, WYRE_REFERRER_ACCOUNT_ID } from '../utils/constants';
 
-const generateSecretKey = () => crypto.randomBytes(30).toString('hex');
-
 const parseError = (error) => (
   error.response ? error.response.data.message : error.toString()
 )
@@ -40,26 +38,20 @@ class WyreService {
       { secretKey },
     )
   )
-
-  createAccount = async () => {
+  
+  createAccount = async (key) => {
     try {
-      // Generate random secret key fo user
-      const secretKey = generateSecretKey();
-      // Register Wyre secret key
-      await this.submitAuthToken(secretKey);
-
       const wyreAccount = {
         type: 'INDIVIDUAL',
         country: 'US',
         subaccount: false,
         referrerAccountId: WYRE_REFERRER_ACCOUNT_ID,
       };
-
-      this.setAuthorizationHeader(secretKey);
+      this.setAuthorizationHeader(key);
       const { data } = await this.service.post(`${this.url}/v3/accounts`, wyreAccount);
       return {
         data,
-        key: secretKey,
+        key: key,
       };
     } catch (error) {
       return {

--- a/src/utils/paymentMethod.js
+++ b/src/utils/paymentMethod.js
@@ -1,0 +1,3 @@
+const hasPaymentMethod = (paymentMethod) => paymentMethod.id;
+
+export default hasPaymentMethod;


### PR DESCRIPTION
- On login added logic that hash user wif key and make a request to wyre API that returns accountID, in case we don't have created account with this key it will return null.

- On manage account, added logic that checks do we have an account in case we don't have it will create wyre account with previously hashed wif key.

- Added condition that check do we have payment method.